### PR TITLE
Initialize Flask/Dash prototype with DB schema

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*.so
+
+# SQLite database
+*.db
+
+# virtual environments
+venv/
+
+# dash build
+frontend/__pycache__/
+

--- a/README.md
+++ b/README.md
@@ -1,0 +1,44 @@
+# Pharma SCM Application
+
+Version: 0.2.0
+
+This project implements an initial prototype for the pharmaceutical supply chain management app described in `Pharmaceutical Supply Chain App Design_.md` and `dbsetup.md`.
+
+## Today's Changes
+
+- Seeded database with sample organizations, users, and a product.
+- Added authentication with `/api/login` and bearer tokens.
+- Created endpoints for users, products, inventory, requests, approvals, and audit logs.
+- Implemented role-based access on sensitive routes.
+- Added multipage Dash dashboards for manufacturer, CFA, and stockist.
+
+## Quick Start
+
+1. Install dependencies:
+
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+2. Run the server:
+
+   ```bash
+   python -m backend.run
+   ```
+
+3. Obtain a token and create a product (example):
+
+   ```bash
+   # login with seeded admin user
+   curl -X POST http://localhost:5000/api/login \
+        -H 'Content-Type: application/json' \
+        -d '{"email": "admin@pharma.com", "password": "adminpass"}'
+
+   # set TOKEN from response and create product
+   curl -X POST http://localhost:5000/api/products \
+        -H "Authorization: Bearer $TOKEN" \
+        -H 'Content-Type: application/json' \
+        -d '{"name": "Pain Reliever", "sku": "PR001", "manufacturer_org_id": "MANUF1"}'
+   ```
+
+SQLite database `pharma.db` will be created automatically in the project root.

--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -1,0 +1,5 @@
+"""Backend package initialization."""
+
+from .app import create_app
+
+__all__ = ["create_app"]

--- a/backend/app.py
+++ b/backend/app.py
@@ -1,0 +1,24 @@
+"""Application factory that sets up Flask and Dash."""
+
+from flask import Flask
+
+from frontend.dash_app import create_dash
+
+from .database import init_db
+from .routes import api_bp
+from . import models
+from .sample_data import seed_data
+
+
+def create_app():
+    """Create Flask app with Dash attached."""
+    init_db()  # Ensure tables exist
+    seed_data()  # Insert sample records for demo
+    server = Flask(__name__)
+    server.register_blueprint(api_bp, url_prefix="/api")
+
+    # Attach Dash frontend to this server
+    create_dash(server)
+
+    return server
+

--- a/backend/database.py
+++ b/backend/database.py
@@ -1,0 +1,20 @@
+"""Database setup and session management."""
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker, declarative_base
+
+DATABASE_URL = "sqlite:///pharma.db"
+
+# Engine created for SQLite database
+engine = create_engine(DATABASE_URL, echo=False, future=True)
+
+# Session factory for database operations
+SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+
+Base = declarative_base()
+
+
+def init_db():
+    """Create tables based on ORM models."""
+    from . import models  # Import models for metadata
+    Base.metadata.create_all(bind=engine)

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,0 +1,181 @@
+"""SQLAlchemy models for pharmaceutical SCM app.
+
+Derived from dbsetup.md schema. Each table includes timestamps for auditing.
+"""
+
+from sqlalchemy import (
+    Column,
+    Integer,
+    String,
+    Text,
+    Date,
+    DateTime,
+    ForeignKey,
+    UniqueConstraint,
+)
+from sqlalchemy.orm import relationship
+from datetime import datetime
+
+from .database import Base
+
+
+class Organization(Base):
+    __tablename__ = "organizations"
+
+    organization_id = Column(String, primary_key=True)
+    name = Column(String, nullable=False)
+    type = Column(String, nullable=False)
+    address = Column(Text)
+    city = Column(Text)
+    state = Column(Text)
+    country = Column(Text)
+    postal_code = Column(Text)
+    phone = Column(Text)
+    fax = Column(Text)
+    email = Column(Text)
+    parent_organization_id = Column(String, ForeignKey("organizations.organization_id"))
+    created_at = Column(DateTime, default=datetime.utcnow)
+    updated_at = Column(DateTime, default=datetime.utcnow)
+
+    parent = relationship("Organization", remote_side=[organization_id])
+
+
+class User(Base):
+    __tablename__ = "users"
+
+    user_id = Column(String, primary_key=True)
+    organization_id = Column(String, ForeignKey("organizations.organization_id"), nullable=False)
+    email = Column(String, unique=True, nullable=False)
+    password_hash = Column(Text, nullable=False)
+    first_name = Column(Text)
+    last_name = Column(Text)
+    role = Column(Text, nullable=False)
+    status = Column(Text, default="active")
+    last_login_at = Column(DateTime)
+    created_at = Column(DateTime, default=datetime.utcnow)
+    updated_at = Column(DateTime, default=datetime.utcnow)
+
+
+class Product(Base):
+    __tablename__ = "products"
+
+    product_id = Column(String, primary_key=True)
+    name = Column(String, nullable=False)
+    sku = Column(String, unique=True, nullable=False)
+    description = Column(Text)
+    unit_of_measure = Column(Text)
+    manufacturer_org_id = Column(String, ForeignKey("organizations.organization_id"))
+    created_at = Column(DateTime, default=datetime.utcnow)
+    updated_at = Column(DateTime, default=datetime.utcnow)
+
+
+class Batch(Base):
+    __tablename__ = "batches"
+
+    batch_id = Column(String, primary_key=True)
+    product_id = Column(String, ForeignKey("products.product_id"), nullable=False)
+    batch_number = Column(String, nullable=False)
+    manufacturing_date = Column(Date)
+    expiry_date = Column(Date)
+    manufacturing_site_name = Column(Text)
+    quality_control_status = Column(Text, default="Released")
+    created_at = Column(DateTime, default=datetime.utcnow)
+    updated_at = Column(DateTime, default=datetime.utcnow)
+
+    __table_args__ = (
+        UniqueConstraint("product_id", "batch_number", name="uix_product_batch"),
+    )
+
+
+class Inventory(Base):
+    __tablename__ = "inventory"
+
+    inventory_record_id = Column(String, primary_key=True)
+    organization_id = Column(String, ForeignKey("organizations.organization_id"), nullable=False)
+    product_id = Column(String, ForeignKey("products.product_id"), nullable=False)
+    batch_id = Column(String, ForeignKey("batches.batch_id"), nullable=False)
+    quantity = Column(Integer, nullable=False)
+    storage_condition = Column(Text)
+    last_updated_at = Column(DateTime, default=datetime.utcnow)
+
+    __table_args__ = (
+        UniqueConstraint("organization_id", "batch_id", name="uix_org_batch"),
+    )
+
+
+class Request(Base):
+    __tablename__ = "requests"
+
+    request_id = Column(String, primary_key=True)
+    request_type = Column(Text, nullable=False)
+    initiator_user_id = Column(String, ForeignKey("users.user_id"), nullable=False)
+    initiator_org_id = Column(String, ForeignKey("organizations.organization_id"), nullable=False)
+    target_org_id = Column(String, ForeignKey("organizations.organization_id"))
+    status = Column(Text, default="Pending")
+    request_date = Column(DateTime, default=datetime.utcnow)
+    completion_date = Column(DateTime)
+    notes = Column(Text)
+    created_at = Column(DateTime, default=datetime.utcnow)
+    updated_at = Column(DateTime, default=datetime.utcnow)
+
+
+class RequestItem(Base):
+    __tablename__ = "request_items"
+
+    request_item_id = Column(String, primary_key=True)
+    request_id = Column(String, ForeignKey("requests.request_id"), nullable=False)
+    product_id = Column(String, ForeignKey("products.product_id"), nullable=False)
+    batch_id = Column(String, ForeignKey("batches.batch_id"), nullable=False)
+    requested_quantity = Column(Integer, nullable=False)
+    approved_quantity = Column(Integer)
+    unit_price = Column(Integer)
+    notes = Column(Text)
+    created_at = Column(DateTime, default=datetime.utcnow)
+
+
+class Approval(Base):
+    __tablename__ = "approvals"
+
+    approval_record_id = Column(String, primary_key=True)
+    request_id = Column(String, ForeignKey("requests.request_id"), nullable=False)
+    approver_user_id = Column(String, ForeignKey("users.user_id"), nullable=False)
+    approval_step = Column(Integer, nullable=False)
+    status = Column(Text, nullable=False)
+    approval_date = Column(DateTime, default=datetime.utcnow)
+    rationale = Column(Text)
+    created_at = Column(DateTime, default=datetime.utcnow)
+
+    __table_args__ = (
+        UniqueConstraint("request_id", "approval_step", name="uix_request_step"),
+    )
+
+
+class Transaction(Base):
+    __tablename__ = "transactions"
+
+    transaction_id = Column(String, primary_key=True)
+    request_id = Column(String, ForeignKey("requests.request_id"))
+    product_id = Column(String, ForeignKey("products.product_id"), nullable=False)
+    batch_id = Column(String, ForeignKey("batches.batch_id"), nullable=False)
+    quantity = Column(Integer, nullable=False)
+    transaction_type = Column(Text, nullable=False)
+    source_org_id = Column(String, ForeignKey("organizations.organization_id"))
+    destination_org_id = Column(String, ForeignKey("organizations.organization_id"))
+    transaction_date = Column(DateTime, default=datetime.utcnow)
+    recorded_by_user_id = Column(String, ForeignKey("users.user_id"), nullable=False)
+    notes = Column(Text)
+    created_at = Column(DateTime, default=datetime.utcnow)
+
+
+class AuditLog(Base):
+    __tablename__ = "audit_logs"
+
+    log_id = Column(String, primary_key=True)
+    user_id = Column(String, ForeignKey("users.user_id"))
+    action_type = Column(Text, nullable=False)
+    table_name = Column(Text)
+    record_id = Column(Text)
+    old_value = Column(Text)
+    new_value = Column(Text)
+    timestamp = Column(DateTime, default=datetime.utcnow)
+

--- a/backend/routes.py
+++ b/backend/routes.py
@@ -1,0 +1,189 @@
+"""Flask routes exposing basic CRUD operations and authentication."""
+
+from flask import Blueprint, request, jsonify, g
+from sqlalchemy.orm import Session
+from .database import SessionLocal
+from . import models
+import uuid
+import hashlib
+
+# In-memory token store for demo purposes
+tokens = {}
+
+
+def hash_password(password: str) -> str:
+    """Return SHA256 hash of password."""
+    return hashlib.sha256(password.encode()).hexdigest()
+
+
+def require_auth(role: str | None = None):
+    """Decorator to require valid token and optional role."""
+
+    def decorator(func):
+        def wrapper(*args, **kwargs):
+            auth = request.headers.get("Authorization", "")
+            token = auth.replace("Bearer ", "")
+            user_id = tokens.get(token)
+            if not user_id:
+                return jsonify({"error": "Unauthorized"}), 401
+
+            session = SessionLocal()
+            user = session.get(models.User, user_id)
+            if not user:
+                return jsonify({"error": "Unauthorized"}), 401
+            if role and user.role != role:
+                return jsonify({"error": "Forbidden"}), 403
+            g.current_user = user
+            return func(*args, **kwargs)
+
+        wrapper.__name__ = func.__name__
+        return wrapper
+
+    return decorator
+
+api_bp = Blueprint("api", __name__)
+
+
+@api_bp.route("/login", methods=["POST"])
+def login():
+    """Authenticate a user and return a token."""
+    data = request.get_json() or {}
+    session = SessionLocal()
+    user = session.query(models.User).filter_by(email=data.get("email")).first()
+    if not user or user.password_hash != hash_password(data.get("password", "")):
+        return jsonify({"error": "Invalid credentials"}), 401
+    token = str(uuid.uuid4())
+    tokens[token] = user.user_id
+    return jsonify({"token": token})
+
+
+@api_bp.route("/organizations", methods=["POST"])
+@require_auth(role="Manufacturer")
+def create_organization():
+    """Create a new organization record.
+
+    WHY: Sample endpoint to demonstrate DB interaction.
+    WHAT: closes #init-setup
+    HOW: Extend by adding authentication. Roll back by dropping table.
+    """
+    data = request.get_json() or {}
+    org = models.Organization(
+        organization_id=data.get("organization_id") or str(uuid.uuid4()),
+        name=data.get("name"),
+        type=data.get("type"),
+        address=data.get("address"),
+    )
+    session: Session = SessionLocal()
+    session.add(org)
+    session.commit()
+    return jsonify({"organization_id": org.organization_id}), 201
+
+
+@api_bp.route("/users", methods=["POST"])
+@require_auth(role="Manufacturer")
+def create_user():
+    """Add a new user linked to an organization."""
+    data = request.get_json() or {}
+    session = SessionLocal()
+    user = models.User(
+        user_id=data.get("user_id") or str(uuid.uuid4()),
+        organization_id=data.get("organization_id"),
+        email=data.get("email"),
+        password_hash=hash_password(data.get("password", "")),
+        role=data.get("role"),
+        first_name=data.get("first_name"),
+        last_name=data.get("last_name"),
+    )
+    session.add(user)
+    session.commit()
+    return jsonify({"user_id": user.user_id}), 201
+
+
+@api_bp.route("/products", methods=["POST"])
+@require_auth(role="Manufacturer")
+def create_product():
+    """Create a product entry."""
+    data = request.get_json() or {}
+    session = SessionLocal()
+    prod = models.Product(
+        product_id=data.get("product_id") or str(uuid.uuid4()),
+        name=data.get("name"),
+        sku=data.get("sku"),
+        manufacturer_org_id=data.get("manufacturer_org_id"),
+    )
+    session.add(prod)
+    session.commit()
+    return jsonify({"product_id": prod.product_id}), 201
+
+
+@api_bp.route("/inventory", methods=["POST"])
+@require_auth()
+def add_inventory():
+    """Record inventory quantities by batch."""
+    data = request.get_json() or {}
+    session = SessionLocal()
+    inv = models.Inventory(
+        inventory_record_id=str(uuid.uuid4()),
+        organization_id=data.get("organization_id"),
+        product_id=data.get("product_id"),
+        batch_id=data.get("batch_id"),
+        quantity=data.get("quantity"),
+    )
+    session.add(inv)
+    session.commit()
+    return jsonify({"inventory_record_id": inv.inventory_record_id}), 201
+
+
+@api_bp.route("/requests", methods=["POST"])
+@require_auth()
+def create_request():
+    """Submit a dispatch or return request."""
+    data = request.get_json() or {}
+    session = SessionLocal()
+    req = models.Request(
+        request_id=str(uuid.uuid4()),
+        request_type=data.get("request_type"),
+        initiator_user_id=g.current_user.user_id,
+        initiator_org_id=g.current_user.organization_id,
+        target_org_id=data.get("target_org_id"),
+        notes=data.get("notes"),
+    )
+    session.add(req)
+    session.commit()
+    return jsonify({"request_id": req.request_id}), 201
+
+
+@api_bp.route("/approvals", methods=["POST"])
+@require_auth()
+def approve_request():
+    """Record an approval step for a request."""
+    data = request.get_json() or {}
+    session = SessionLocal()
+    appr = models.Approval(
+        approval_record_id=str(uuid.uuid4()),
+        request_id=data.get("request_id"),
+        approver_user_id=g.current_user.user_id,
+        approval_step=data.get("approval_step", 1),
+        status=data.get("status"),
+    )
+    session.add(appr)
+    session.commit()
+    return jsonify({"approval_record_id": appr.approval_record_id}), 201
+
+
+@api_bp.route("/audit-logs", methods=["GET"])
+@require_auth()
+def list_audit_logs():
+    """Return all audit logs."""
+    session = SessionLocal()
+    logs = session.query(models.AuditLog).all()
+    return jsonify([
+        {
+            "log_id": l.log_id,
+            "action_type": l.action_type,
+            "table_name": l.table_name,
+            "record_id": l.record_id,
+            "timestamp": l.timestamp.isoformat(),
+        }
+        for l in logs
+    ])

--- a/backend/run.py
+++ b/backend/run.py
@@ -1,0 +1,14 @@
+"""Entry point for running the Flask application."""
+
+from .app import create_app
+
+
+def main():
+    app = create_app()
+    # Running with debug for development
+    app.run(debug=True)
+
+
+if __name__ == "__main__":
+    main()
+

--- a/backend/sample_data.py
+++ b/backend/sample_data.py
@@ -1,0 +1,75 @@
+"""Seed sample data for testing authentication and feature operations.
+
+WHY: Provide initial orgs, users, and products so devs can immediately test
+login and CRUD endpoints.
+WHAT: closes #seed-data
+HOW: Extend with more sample batches. Roll back by removing this file.
+"""
+
+import uuid
+from .database import SessionLocal
+from . import models
+from .routes import hash_password
+
+
+def seed_data():
+    """Insert example organizations, users, and a product if DB is empty."""
+    session = SessionLocal()
+    if session.query(models.Organization).first():
+        session.close()
+        return
+
+    manuf = models.Organization(
+        organization_id="MANUF1",
+        name="Acme Pharma",
+        type="Manufacturer",
+    )
+    cfa = models.Organization(
+        organization_id="CFA1",
+        name="Central CFA",
+        type="CFA",
+        parent_organization_id="MANUF1",
+    )
+    stock = models.Organization(
+        organization_id="STOCK1",
+        name="City Stockist",
+        type="Stockist",
+        parent_organization_id="CFA1",
+    )
+    session.add_all([manuf, cfa, stock])
+
+    admin = models.User(
+        user_id="USR1",
+        organization_id="MANUF1",
+        email="admin@pharma.com",
+        password_hash=hash_password("adminpass"),
+        role="Manufacturer",
+        first_name="Admin",
+        last_name="User",
+    )
+    cfa_user = models.User(
+        user_id="USR2",
+        organization_id="CFA1",
+        email="cfa@pharma.com",
+        password_hash=hash_password("cfapass"),
+        role="CFA",
+    )
+    stock_user = models.User(
+        user_id="USR3",
+        organization_id="STOCK1",
+        email="stock@pharma.com",
+        password_hash=hash_password("stockpass"),
+        role="Stockist",
+    )
+    session.add_all([admin, cfa_user, stock_user])
+
+    prod = models.Product(
+        product_id="PROD1",
+        name="Pain Reliever",
+        sku="PR001",
+        manufacturer_org_id="MANUF1",
+    )
+    session.add(prod)
+
+    session.commit()
+    session.close()

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,15 @@
+# Architecture Overview
+
+```
++-------------------+     HTTP     +-------------------+
+|   Dash Frontend   | <---------> |    Flask API w/ Auth|
++-------------------+             +-------------------+
+        |                                   |
+        | SQLAlchemy ORM                    |
+        v                                   v
++-------------------+             +-------------------+
+|    SQLite DB      |             |   Models/Tables   |
++-------------------+             +-------------------+
+```
+
+The application uses Flask as the API layer (now with bearer-token authentication) and Dash for the UI. SQLAlchemy manages the SQLite database described in `dbsetup.md`. Multiple dashboards (manufacturer, CFA, stockist) connect via authenticated REST calls.

--- a/frontend/cfa.py
+++ b/frontend/cfa.py
@@ -1,0 +1,9 @@
+from dash import html
+
+
+def layout():
+    """CFA dashboard layout."""
+    return html.Div([
+        html.H2("CFA Dashboard"),
+        html.P("Track inventory and dispatch requests."),
+    ])

--- a/frontend/dash_app.py
+++ b/frontend/dash_app.py
@@ -1,0 +1,33 @@
+"""Dash application to provide a minimal UI."""
+
+# This module is kept separate to allow future expansion
+# of the UI without impacting Flask API routes.
+
+from dash import Dash, html, dcc, Output, Input
+from .manufacturer import layout as manufacturer_layout
+from .cfa import layout as cfa_layout
+from .stockist import layout as stockist_layout
+
+
+def create_dash(server):
+    """Factory to create Dash app and attach to given Flask server."""
+    dash_app = Dash(__name__, server=server, url_base_pathname="/dashboard/")
+    dash_app.layout = html.Div([
+        dcc.Location(id="url"),
+        html.Div(id="page-content"),
+    ])
+
+    @dash_app.callback(Output("page-content", "children"), Input("url", "pathname"))
+    def display_page(pathname):
+        if pathname.endswith("/manufacturer"):
+            return manufacturer_layout()
+        if pathname.endswith("/cfa"):
+            return cfa_layout()
+        if pathname.endswith("/stockist"):
+            return stockist_layout()
+        return html.Div([
+            html.H1("Pharma SCM Dashboard"),
+            html.P("Select a dashboard page."),
+        ])
+
+    return dash_app

--- a/frontend/manufacturer.py
+++ b/frontend/manufacturer.py
@@ -1,0 +1,9 @@
+from dash import html
+
+
+def layout():
+    """Manufacturer dashboard layout."""
+    return html.Div([
+        html.H2("Manufacturer Dashboard"),
+        html.P("Manage products, users and approvals here."),
+    ])

--- a/frontend/stockist.py
+++ b/frontend/stockist.py
@@ -1,0 +1,9 @@
+from dash import html
+
+
+def layout():
+    """Stockist dashboard layout."""
+    return html.Div([
+        html.H2("Stockist Dashboard"),
+        html.P("Submit orders and view approvals."),
+    ])

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+Flask==2.2.5
+Dash==2.14.2
+SQLAlchemy==2.0.23
+pandas==2.1.4


### PR DESCRIPTION
## Summary
- scaffold initial Flask application with Dash frontend
- implement SQLAlchemy models from `dbsetup.md`
- expose a `/api/organizations` endpoint
- provide basic architecture docs and quick start instructions

## Testing
- `pip install -r requirements.txt`
- `python -m backend.run` (started server)


------
https://chatgpt.com/codex/tasks/task_e_685a7fd28554832a817b3647434cbae4