### PR TITLE
Initialize Flask/Dash prototype with DB schema

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*.so
+
+# SQLite database
+*.db
+
+# virtual environments
+venv/
+
+# dash build
+frontend/__pycache__/
+

--- a/README.md
+++ b/README.md
@@ -1,0 +1,41 @@
+# Pharma SCM Application
+
+Version: 0.2.0
+
+This project implements an initial prototype for the pharmaceutical supply chain management app described in `Pharmaceutical Supply Chain App Design_.md` and `dbsetup.md`.
+
+## Today's Changes
+
+- Added sample seed data for organizations, users, product and inventory.
+- Implemented authentication endpoints `/api/users` and `/api/login`.
+- Added protected `/api/inventory` endpoint.
+- Created Dash dashboards for manufacturer, CFA and stockist roles.
+- Server now listens on port `8787`.
+
+## Quick Start
+
+1. Install dependencies:
+
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+2. Run the server:
+
+   ```bash
+   python -m backend.run
+   ```
+
+3. Authenticate and list inventory (examples using `curl`):
+
+   ```bash
+   # login with seeded manufacturer user
+   curl -X POST http://localhost:8787/api/login \
+        -H 'Content-Type: application/json' \
+        -d '{"email": "manuf@example.com", "password": "password"}'
+   # use the returned token
+   curl http://localhost:8787/api/inventory \
+        -H "Authorization: <TOKEN>"
+   ```
+
+SQLite database `pharma.db` will be created automatically in the project root.

--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -1,0 +1,5 @@
+"""Backend package initialization."""
+
+from .app import create_app
+
+__all__ = ["create_app"]

--- a/backend/app.py
+++ b/backend/app.py
@@ -1,0 +1,24 @@
+"""Application factory that sets up Flask and Dash."""
+
+from flask import Flask
+
+from frontend.dash_app import create_dash
+
+from .database import init_db
+from .routes import api_bp
+from . import models
+from . import sample_data
+
+
+def create_app():
+    """Create Flask app with Dash attached."""
+    init_db()  # Ensure tables exist
+    sample_data.seed()  # WHY: provide sample records for testing auth
+    server = Flask(__name__)
+    server.register_blueprint(api_bp, url_prefix="/api")
+
+    # Attach Dash frontend to this server
+    create_dash(server)
+
+    return server
+

--- a/backend/auth.py
+++ b/backend/auth.py
@@ -1,0 +1,61 @@
+"""Simple token-based auth for demonstration."""
+
+import uuid
+from functools import wraps
+from flask import request, jsonify
+from werkzeug.security import check_password_hash
+
+from .database import SessionLocal
+from . import models
+
+# In-memory token store {token: user_id}
+auth_tokens = {}
+
+
+def generate_token(user_id):
+    token = str(uuid.uuid4())
+    auth_tokens[token] = user_id
+    return token
+
+
+def get_user_from_token(token):
+    user_id = auth_tokens.get(token)
+    if not user_id:
+        return None
+    session = SessionLocal()
+    user = session.get(models.User, user_id)
+    session.close()
+    return user
+
+
+def token_required(role=None):
+    """Decorator to protect endpoints with token auth and optional role."""
+
+    def decorator(f):
+        @wraps(f)
+        def wrapper(*args, **kwargs):
+            token = request.headers.get("Authorization")
+            if not token:
+                return jsonify({"error": "Auth token required"}), 401
+            user = get_user_from_token(token)
+            if not user:
+                return jsonify({"error": "Invalid token"}), 401
+            if role and user.role != role:
+                return jsonify({"error": "Forbidden"}), 403
+            request.user = user
+            return f(*args, **kwargs)
+
+        return wrapper
+
+    return decorator
+
+
+def login(email, password):
+    session = SessionLocal()
+    user = session.query(models.User).filter_by(email=email).first()
+    if not user or not check_password_hash(user.password_hash, password):
+        session.close()
+        return None
+    token = generate_token(user.user_id)
+    session.close()
+    return token

--- a/backend/database.py
+++ b/backend/database.py
@@ -1,0 +1,20 @@
+"""Database setup and session management."""
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker, declarative_base
+
+DATABASE_URL = "sqlite:///pharma.db"
+
+# Engine created for SQLite database
+engine = create_engine(DATABASE_URL, echo=False, future=True)
+
+# Session factory for database operations
+SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+
+Base = declarative_base()
+
+
+def init_db():
+    """Create tables based on ORM models."""
+    from . import models  # Import models for metadata
+    Base.metadata.create_all(bind=engine)

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,0 +1,181 @@
+"""SQLAlchemy models for pharmaceutical SCM app.
+
+Derived from dbsetup.md schema. Each table includes timestamps for auditing.
+"""
+
+from sqlalchemy import (
+    Column,
+    Integer,
+    String,
+    Text,
+    Date,
+    DateTime,
+    ForeignKey,
+    UniqueConstraint,
+)
+from sqlalchemy.orm import relationship
+from datetime import datetime
+
+from .database import Base
+
+
+class Organization(Base):
+    __tablename__ = "organizations"
+
+    organization_id = Column(String, primary_key=True)
+    name = Column(String, nullable=False)
+    type = Column(String, nullable=False)
+    address = Column(Text)
+    city = Column(Text)
+    state = Column(Text)
+    country = Column(Text)
+    postal_code = Column(Text)
+    phone = Column(Text)
+    fax = Column(Text)
+    email = Column(Text)
+    parent_organization_id = Column(String, ForeignKey("organizations.organization_id"))
+    created_at = Column(DateTime, default=datetime.utcnow)
+    updated_at = Column(DateTime, default=datetime.utcnow)
+
+    parent = relationship("Organization", remote_side=[organization_id])
+
+
+class User(Base):
+    __tablename__ = "users"
+
+    user_id = Column(String, primary_key=True)
+    organization_id = Column(String, ForeignKey("organizations.organization_id"), nullable=False)
+    email = Column(String, unique=True, nullable=False)
+    password_hash = Column(Text, nullable=False)
+    first_name = Column(Text)
+    last_name = Column(Text)
+    role = Column(Text, nullable=False)
+    status = Column(Text, default="active")
+    last_login_at = Column(DateTime)
+    created_at = Column(DateTime, default=datetime.utcnow)
+    updated_at = Column(DateTime, default=datetime.utcnow)
+
+
+class Product(Base):
+    __tablename__ = "products"
+
+    product_id = Column(String, primary_key=True)
+    name = Column(String, nullable=False)
+    sku = Column(String, unique=True, nullable=False)
+    description = Column(Text)
+    unit_of_measure = Column(Text)
+    manufacturer_org_id = Column(String, ForeignKey("organizations.organization_id"))
+    created_at = Column(DateTime, default=datetime.utcnow)
+    updated_at = Column(DateTime, default=datetime.utcnow)
+
+
+class Batch(Base):
+    __tablename__ = "batches"
+
+    batch_id = Column(String, primary_key=True)
+    product_id = Column(String, ForeignKey("products.product_id"), nullable=False)
+    batch_number = Column(String, nullable=False)
+    manufacturing_date = Column(Date)
+    expiry_date = Column(Date)
+    manufacturing_site_name = Column(Text)
+    quality_control_status = Column(Text, default="Released")
+    created_at = Column(DateTime, default=datetime.utcnow)
+    updated_at = Column(DateTime, default=datetime.utcnow)
+
+    __table_args__ = (
+        UniqueConstraint("product_id", "batch_number", name="uix_product_batch"),
+    )
+
+
+class Inventory(Base):
+    __tablename__ = "inventory"
+
+    inventory_record_id = Column(String, primary_key=True)
+    organization_id = Column(String, ForeignKey("organizations.organization_id"), nullable=False)
+    product_id = Column(String, ForeignKey("products.product_id"), nullable=False)
+    batch_id = Column(String, ForeignKey("batches.batch_id"), nullable=False)
+    quantity = Column(Integer, nullable=False)
+    storage_condition = Column(Text)
+    last_updated_at = Column(DateTime, default=datetime.utcnow)
+
+    __table_args__ = (
+        UniqueConstraint("organization_id", "batch_id", name="uix_org_batch"),
+    )
+
+
+class Request(Base):
+    __tablename__ = "requests"
+
+    request_id = Column(String, primary_key=True)
+    request_type = Column(Text, nullable=False)
+    initiator_user_id = Column(String, ForeignKey("users.user_id"), nullable=False)
+    initiator_org_id = Column(String, ForeignKey("organizations.organization_id"), nullable=False)
+    target_org_id = Column(String, ForeignKey("organizations.organization_id"))
+    status = Column(Text, default="Pending")
+    request_date = Column(DateTime, default=datetime.utcnow)
+    completion_date = Column(DateTime)
+    notes = Column(Text)
+    created_at = Column(DateTime, default=datetime.utcnow)
+    updated_at = Column(DateTime, default=datetime.utcnow)
+
+
+class RequestItem(Base):
+    __tablename__ = "request_items"
+
+    request_item_id = Column(String, primary_key=True)
+    request_id = Column(String, ForeignKey("requests.request_id"), nullable=False)
+    product_id = Column(String, ForeignKey("products.product_id"), nullable=False)
+    batch_id = Column(String, ForeignKey("batches.batch_id"), nullable=False)
+    requested_quantity = Column(Integer, nullable=False)
+    approved_quantity = Column(Integer)
+    unit_price = Column(Integer)
+    notes = Column(Text)
+    created_at = Column(DateTime, default=datetime.utcnow)
+
+
+class Approval(Base):
+    __tablename__ = "approvals"
+
+    approval_record_id = Column(String, primary_key=True)
+    request_id = Column(String, ForeignKey("requests.request_id"), nullable=False)
+    approver_user_id = Column(String, ForeignKey("users.user_id"), nullable=False)
+    approval_step = Column(Integer, nullable=False)
+    status = Column(Text, nullable=False)
+    approval_date = Column(DateTime, default=datetime.utcnow)
+    rationale = Column(Text)
+    created_at = Column(DateTime, default=datetime.utcnow)
+
+    __table_args__ = (
+        UniqueConstraint("request_id", "approval_step", name="uix_request_step"),
+    )
+
+
+class Transaction(Base):
+    __tablename__ = "transactions"
+
+    transaction_id = Column(String, primary_key=True)
+    request_id = Column(String, ForeignKey("requests.request_id"))
+    product_id = Column(String, ForeignKey("products.product_id"), nullable=False)
+    batch_id = Column(String, ForeignKey("batches.batch_id"), nullable=False)
+    quantity = Column(Integer, nullable=False)
+    transaction_type = Column(Text, nullable=False)
+    source_org_id = Column(String, ForeignKey("organizations.organization_id"))
+    destination_org_id = Column(String, ForeignKey("organizations.organization_id"))
+    transaction_date = Column(DateTime, default=datetime.utcnow)
+    recorded_by_user_id = Column(String, ForeignKey("users.user_id"), nullable=False)
+    notes = Column(Text)
+    created_at = Column(DateTime, default=datetime.utcnow)
+
+
+class AuditLog(Base):
+    __tablename__ = "audit_logs"
+
+    log_id = Column(String, primary_key=True)
+    user_id = Column(String, ForeignKey("users.user_id"))
+    action_type = Column(Text, nullable=False)
+    table_name = Column(Text)
+    record_id = Column(Text)
+    old_value = Column(Text)
+    new_value = Column(Text)
+    timestamp = Column(DateTime, default=datetime.utcnow)
+

--- a/backend/routes.py
+++ b/backend/routes.py
@@ -1,0 +1,86 @@
+"""Flask routes exposing basic CRUD operations."""
+
+from flask import Blueprint, request, jsonify
+from sqlalchemy.orm import Session
+from werkzeug.security import generate_password_hash
+from .database import SessionLocal
+from . import models
+from . import auth
+import uuid
+
+api_bp = Blueprint("api", __name__)
+
+
+@api_bp.route("/organizations", methods=["POST"])
+def create_organization():
+    """Create a new organization record.
+
+    WHY: Sample endpoint to demonstrate DB interaction.
+    WHAT: closes #init-setup
+    HOW: Extend by adding authentication. Roll back by dropping table.
+    """
+    data = request.get_json() or {}
+    org = models.Organization(
+        organization_id=data.get("organization_id") or str(uuid.uuid4()),
+        name=data.get("name"),
+        type=data.get("type"),
+        address=data.get("address"),
+    )
+    session: Session = SessionLocal()
+    session.add(org)
+    session.commit()
+    return jsonify({"organization_id": org.organization_id}), 201
+
+
+@api_bp.route("/users", methods=["POST"])
+def create_user():
+    """Register a new user and assign role.
+
+    WHY: required for role-based access testing.
+    WHAT: closes #user-management
+    HOW: Extend with email verification. Roll back by dropping table.
+    """
+    data = request.get_json() or {}
+    user = models.User(
+        user_id=str(uuid.uuid4()),
+        organization_id=data.get("organization_id"),
+        email=data.get("email"),
+        password_hash=generate_password_hash(data.get("password", "")),
+        role=data.get("role"),
+        first_name=data.get("first_name"),
+    )
+    session: Session = SessionLocal()
+    session.add(user)
+    session.commit()
+    return jsonify({"user_id": user.user_id}), 201
+
+
+@api_bp.route("/login", methods=["POST"])
+def login():
+    """Return auth token if credentials are valid."""
+    data = request.get_json() or {}
+    token = auth.login(data.get("email"), data.get("password"))
+    if not token:
+        return jsonify({"error": "invalid credentials"}), 401
+    return jsonify({"token": token})
+
+
+@api_bp.route("/inventory", methods=["GET"])
+@auth.token_required()
+def list_inventory():
+    """List inventory records for the user's organization."""
+    session: Session = SessionLocal()
+    records = session.query(models.Inventory).filter_by(
+        organization_id=request.user.organization_id
+    ).all()
+    out = [
+        {
+            "inventory_record_id": r.inventory_record_id,
+            "product_id": r.product_id,
+            "batch_id": r.batch_id,
+            "quantity": r.quantity,
+        }
+        for r in records
+    ]
+    session.close()
+    return jsonify(out)

--- a/backend/run.py
+++ b/backend/run.py
@@ -1,0 +1,14 @@
+"""Entry point for running the Flask application."""
+
+from .app import create_app
+
+
+def main():
+    app = create_app()
+    # Running with debug for development
+    app.run(debug=True, port=8787)
+
+
+if __name__ == "__main__":
+    main()
+

--- a/backend/sample_data.py
+++ b/backend/sample_data.py
@@ -1,0 +1,91 @@
+"""Seed data for development/testing."""
+
+import uuid
+from werkzeug.security import generate_password_hash
+from .database import SessionLocal
+from . import models
+
+
+def seed():
+    """Insert sample organizations, users, and products if not already present."""
+    session = SessionLocal()
+    if session.query(models.Organization).first():
+        session.close()
+        return
+
+    manuf = models.Organization(
+        organization_id="MANUF001",
+        name="Sample Manufacturer",
+        type="Manufacturer",
+    )
+    cfa = models.Organization(
+        organization_id="CFA001",
+        name="Sample CFA",
+        type="CFA",
+        parent_organization_id=manuf.organization_id,
+    )
+    stock = models.Organization(
+        organization_id="STOCK001",
+        name="Sample Stockist",
+        type="Stockist",
+        parent_organization_id=cfa.organization_id,
+    )
+    session.add_all([manuf, cfa, stock])
+
+    users = [
+        models.User(
+            user_id=str(uuid.uuid4()),
+            organization_id=manuf.organization_id,
+            email="manuf@example.com",
+            password_hash=generate_password_hash("password"),
+            role="manufacturer",
+            first_name="Manu",
+        ),
+        models.User(
+            user_id=str(uuid.uuid4()),
+            organization_id=cfa.organization_id,
+            email="cfa@example.com",
+            password_hash=generate_password_hash("password"),
+            role="cfa",
+            first_name="Cfa",
+        ),
+        models.User(
+            user_id=str(uuid.uuid4()),
+            organization_id=stock.organization_id,
+            email="stock@example.com",
+            password_hash=generate_password_hash("password"),
+            role="stockist",
+            first_name="Stock",
+        ),
+    ]
+    session.add_all(users)
+
+    product = models.Product(
+        product_id="PROD001",
+        name="PainRelief",
+        sku="PR-100",
+        description="Sample product",
+        unit_of_measure="box",
+        manufacturer_org_id=manuf.organization_id,
+    )
+    session.add(product)
+
+    batch = models.Batch(
+        batch_id="BATCH001",
+        product_id=product.product_id,
+        batch_number="B-001",
+        manufacturing_site_name="Site A",
+    )
+    session.add(batch)
+
+    inventory = models.Inventory(
+        inventory_record_id=str(uuid.uuid4()),
+        organization_id=manuf.organization_id,
+        product_id=product.product_id,
+        batch_id=batch.batch_id,
+        quantity=100,
+    )
+    session.add(inventory)
+
+    session.commit()
+    session.close()

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,17 @@
+# Architecture Overview
+
+```
++-------------------+     HTTP     +-------------------+
+|   Dash Frontend   | <---------> |    Flask API      |
++-------------------+             +-------------------+
+        |                                   |
+        | SQLAlchemy ORM                    |
+        v                                   v
++-------------------+             +-------------------+
+|    SQLite DB      |             |   Models/Tables   |
++-------------------+             +-------------------+
+```
+
+The application uses Flask as the API layer and Dash for the UI. SQLAlchemy manages the SQLite database described in `dbsetup.md`.
+
+Authentication tokens are issued via `/api/login` and required for inventory endpoints. Seed data is loaded on startup for demo purposes.

--- a/frontend/cfa.py
+++ b/frontend/cfa.py
@@ -1,0 +1,6 @@
+from dash import html
+
+layout = html.Div([
+    html.H2("CFA Dashboard"),
+    html.P("CFA operations"),
+])

--- a/frontend/dash_app.py
+++ b/frontend/dash_app.py
@@ -1,0 +1,35 @@
+"""Dash application to provide a minimal UI."""
+
+# This module is kept separate to allow future expansion
+# of the UI without impacting Flask API routes.
+
+import dash
+from dash import Dash, html, dcc
+from . import manufacturer, cfa, stockist
+
+
+def create_dash(server):
+    """Factory to create Dash app and attach to given Flask server."""
+    dash_app = Dash(__name__, server=server, url_base_pathname="/dashboard/", suppress_callback_exceptions=True)
+
+    dash_app.layout = html.Div([
+        dcc.Location(id="url"),
+        html.Div(id="page-content"),
+    ])
+
+    @dash_app.callback(
+        dash.dependencies.Output("page-content", "children"),
+        [dash.dependencies.Input("url", "pathname")],
+    )
+    def display_page(pathname):
+        if pathname == "/dashboard/manufacturer":
+            return manufacturer.layout
+        if pathname == "/dashboard/cfa":
+            return cfa.layout
+        if pathname == "/dashboard/stockist":
+            return stockist.layout
+        return html.Div([
+            html.H1("Pharma SCM Dashboard"),
+            html.P("Select role dashboard."),
+        ])
+    return dash_app

--- a/frontend/manufacturer.py
+++ b/frontend/manufacturer.py
@@ -1,0 +1,6 @@
+from dash import html
+
+layout = html.Div([
+    html.H2("Manufacturer Dashboard"),
+    html.P("Operations overview"),
+])

--- a/frontend/stockist.py
+++ b/frontend/stockist.py
@@ -1,0 +1,6 @@
+from dash import html
+
+layout = html.Div([
+    html.H2("Stockist Dashboard"),
+    html.P("Stockist operations"),
+])

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+Flask==2.2.5
+Dash==2.14.2
+SQLAlchemy==2.0.23
+pandas==2.1.4


### PR DESCRIPTION
## Summary
- scaffold initial Flask application with Dash frontend
- implement SQLAlchemy models from `dbsetup.md`
- expose a `/api/organizations` endpoint
- provide basic architecture docs and quick start instructions
- add auth layer, seed data and role dashboards

## Testing
- `pip install -r requirements.txt`
- `python -m backend.run` *(fails: Address already in use)*


------
https://chatgpt.com/codex/tasks/task_e_685a7fd28554832a817b3647434cbae4