### PR TITLE
Allow DB config via env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 # Pharma SCM Application
 
-Version: 0.2.0
+Version: 0.2.1
 
 This project implements an initial prototype for the pharmaceutical supply chain management app described in `Pharmaceutical Supply Chain App Design_.md` and `dbsetup.md`.
 
@@ -12,22 +12,29 @@ This project implements an initial prototype for the pharmaceutical supply chain
 - Created endpoints for users, products, inventory, requests, approvals, and audit logs.
 - Implemented role-based access on sensitive routes.
 - Added multipage Dash dashboards for manufacturer, CFA, and stockist.
+- Now reads `DATABASE_URL` from environment for DB connection.
 
 ## Quick Start
 
-1. Install dependencies:
+1. (Optional) set a custom database URL:
+
+   ```bash
+   export DATABASE_URL=sqlite:///pharma.db
+   ```
+
+2. Install dependencies:
 
    ```bash
    pip install -r requirements.txt
    ```
 
-2. Run the server:
+3. Run the server:
 
    ```bash
    python -m backend.run
    ```
 
-3. Obtain a token and create a product (example):
+4. Obtain a token and create a product (example):
 
    ```bash
    # login with seeded admin user
@@ -42,4 +49,4 @@ This project implements an initial prototype for the pharmaceutical supply chain
         -d '{"name": "Pain Reliever", "sku": "PR001", "manufacturer_org_id": "MANUF1"}'
    ```
 
-SQLite database `pharma.db` will be created automatically in the project root.
+If `DATABASE_URL` is not set, SQLite database `pharma.db` will be created automatically in the project root.

--- a/backend/database.py
+++ b/backend/database.py
@@ -2,10 +2,14 @@
 
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker, declarative_base
+import os
 
-DATABASE_URL = "sqlite:///pharma.db"
+# WHY: let deployments configure the DB without changing code
+# WHAT: closes #config-db-url
+# HOW: extend by using a PostgreSQL URI; roll back by hardcoding
+DATABASE_URL = os.environ.get("DATABASE_URL", "sqlite:///pharma.db")
 
-# Engine created for SQLite database
+# Engine created for configured database (defaults to SQLite)
 engine = create_engine(DATABASE_URL, echo=False, future=True)
 
 # Session factory for database operations

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -10,8 +10,8 @@
         | SQLAlchemy ORM                    |
         v                                   v
 +-------------------+             +-------------------+
-|    SQLite DB      |             |   Models/Tables   |
+|  DB via DATABASE_URL |             |   Models/Tables   |
 +-------------------+             +-------------------+
 ```
 
-The application uses Flask as the API layer (now with bearer-token authentication) and Dash for the UI. SQLAlchemy manages the SQLite database described in `dbsetup.md`. Multiple dashboards (manufacturer, CFA, stockist) connect via authenticated REST calls.
+The application uses Flask as the API layer (now with bearer-token authentication) and Dash for the UI. SQLAlchemy manages the database configured through the `DATABASE_URL` environment variable (defaulting to SQLite). Multiple dashboards (manufacturer, CFA, stockist) connect via authenticated REST calls.


### PR DESCRIPTION
## Summary
- make `backend/database.py` read `DATABASE_URL` from environment
- mention `DATABASE_URL` in README quick-start
- update architecture doc to show configurable DB

## Testing
- `pip install -r requirements.txt`
- `python -m backend.run` (fails without packages, then succeeds after install)


------
https://chatgpt.com/codex/tasks/task_e_685ab0e98168832abce2404666a4a6b9