### PR TITLE
Expose backend version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 
 # Pharma SCM Application
 
-Version: 0.2.1
+Version: 0.2.2
 
-This project implements an initial prototype for the pharmaceutical supply chain management app described in `Pharmaceutical Supply Chain App Design_.md` and `dbsetup.md`.
+This project implements an initial prototype for the pharmaceutical supply chain management app described in `dbsetup.md`.
 
 ## Today's Changes
 
@@ -13,6 +13,7 @@ This project implements an initial prototype for the pharmaceutical supply chain
 - Implemented role-based access on sensitive routes.
 - Added multipage Dash dashboards for manufacturer, CFA, and stockist.
 - Now reads `DATABASE_URL` from environment for DB connection.
+- Added `/api/version` endpoint to report backend version.
 
 ## Quick Start
 
@@ -28,22 +29,28 @@ This project implements an initial prototype for the pharmaceutical supply chain
    pip install -r requirements.txt
    ```
 
-3. Run the server:
+3. Run the server (optional port arg):
 
    ```bash
-   python -m backend.run
+   python -m backend.run 5055
    ```
 
-4. Obtain a token and create a product (example):
+4. Check the backend version:
+
+   ```bash
+   curl http://localhost:5055/api/version
+   ```
+
+5. Obtain a token and create a product (example):
 
    ```bash
    # login with seeded admin user
-   curl -X POST http://localhost:5000/api/login \
+   curl -X POST http://localhost:5055/api/login \
         -H 'Content-Type: application/json' \
         -d '{"email": "admin@pharma.com", "password": "adminpass"}'
 
    # set TOKEN from response and create product
-   curl -X POST http://localhost:5000/api/products \
+   curl -X POST http://localhost:5055/api/products \
         -H "Authorization: Bearer $TOKEN" \
         -H 'Content-Type: application/json' \
         -d '{"name": "Pain Reliever", "sku": "PR001", "manufacturer_org_id": "MANUF1"}'

--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -1,5 +1,6 @@
 """Backend package initialization."""
 
 from .app import create_app
+from .version import VERSION  # central version constant
 
 __all__ = ["create_app"]

--- a/backend/routes.py
+++ b/backend/routes.py
@@ -1,6 +1,7 @@
 """Flask routes exposing basic CRUD operations and authentication."""
 
 from flask import Blueprint, request, jsonify, g
+from .version import VERSION
 from sqlalchemy.orm import Session
 from .database import SessionLocal
 from . import models
@@ -55,6 +56,17 @@ def login():
     token = str(uuid.uuid4())
     tokens[token] = user.user_id
     return jsonify({"token": token})
+
+
+@api_bp.route("/version", methods=["GET"])
+def get_version():
+    """Return backend version.
+
+    WHY: allow clients to verify API compatibility.
+    WHAT: closes #improve-readme
+    HOW: update VERSION constant or remove route to roll back.
+    """
+    return jsonify({"version": VERSION})
 
 
 @api_bp.route("/organizations", methods=["POST"])

--- a/backend/run.py
+++ b/backend/run.py
@@ -3,12 +3,17 @@
 from .app import create_app
 
 
-def main():
+def main(port: int = 5000):
+    """Launch the development server on the given port."""
     app = create_app()
-    # Running with debug for development
-    app.run(debug=True)
+    # WHY: allow running on alternate ports when 5000 is taken
+    # WHAT: closes #improve-readme
+    # HOW: pass a new port or revert to default 5000
+    app.run(debug=True, port=port)
 
 
 if __name__ == "__main__":
-    main()
+    import sys
+    port = int(sys.argv[1]) if len(sys.argv) > 1 else 5000
+    main(port)
 

--- a/backend/version.py
+++ b/backend/version.py
@@ -1,0 +1,3 @@
+"""Package-wide version constant."""
+
+VERSION = "0.2.2"

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -15,3 +15,5 @@
 ```
 
 The application uses Flask as the API layer (now with bearer-token authentication) and Dash for the UI. SQLAlchemy manages the database configured through the `DATABASE_URL` environment variable (defaulting to SQLite). Multiple dashboards (manufacturer, CFA, stockist) connect via authenticated REST calls.
+
+- Added `/api/version` to expose backend version for UI checks.

--- a/frontend/manufacturer.py
+++ b/frontend/manufacturer.py
@@ -1,4 +1,5 @@
 from dash import html
+from backend.version import VERSION  # display API version
 
 
 def layout():
@@ -6,4 +7,5 @@ def layout():
     return html.Div([
         html.H2("Manufacturer Dashboard"),
         html.P("Manage products, users and approvals here."),
+        html.Small(f"Backend version: {VERSION}"),
     ])


### PR DESCRIPTION
## Summary
- expose backend version via new `/api/version` route
- display backend version in manufacturer dashboard
- allow running backend on a custom port
- document version endpoint and custom port usage
- record version endpoint in architecture notes

## Testing
- `python -m backend.run 5055` *(server started)*

------
https://chatgpt.com/codex/tasks/task_e_685abccf89d4832a928535468bdb432d