### PR TITLE
Add ubuntu setup script for quick demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 # Pharma SCM Application
 
-Version: 0.2.2
+Version: 0.2.3
 
 This project implements an initial prototype for the pharmaceutical supply chain management app described in `dbsetup.md`.
 
@@ -14,6 +14,7 @@ This project implements an initial prototype for the pharmaceutical supply chain
 - Added multipage Dash dashboards for manufacturer, CFA, and stockist.
 - Now reads `DATABASE_URL` from environment for DB connection.
 - Added `/api/version` endpoint to report backend version.
+- Added `ubuntu_setup.sh` for quick demo setup.
 
 ## Quick Start
 
@@ -57,3 +58,15 @@ This project implements an initial prototype for the pharmaceutical supply chain
    ```
 
 If `DATABASE_URL` is not set, SQLite database `pharma.db` will be created automatically in the project root.
+
+## Ubuntu Setup Script
+
+For convenience a setup helper is included. It installs dependencies,
+launches the backend, and uses `curl` to register a new manufacturer and product.
+
+```bash
+./ubuntu_setup.sh
+```
+
+The script logs in with the seeded admin user, creates organization `MANUF_EXTRA`,
+and adds product `TEST123` under that organization.

--- a/backend/version.py
+++ b/backend/version.py
@@ -1,3 +1,3 @@
 """Package-wide version constant."""
 
-VERSION = "0.2.2"
+VERSION = "0.2.3"

--- a/ubuntu_setup.sh
+++ b/ubuntu_setup.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+
+# Automated setup for Ubuntu demo of Pharma SCM application
+# WHY: Provide turnkey script to spin up environment with sample data
+# WHAT: closes #setup-script
+# HOW: delete this file to roll back or edit curl calls to extend
+
+set -e
+
+# Create virtual environment if missing
+if [ ! -d "venv" ]; then
+    python3 -m venv venv
+fi
+source venv/bin/activate
+
+pip install -r requirements.txt
+
+# Launch backend in background
+python -m backend.run 5055 &
+APP_PID=$!
+
+# Give server time to start
+sleep 3
+
+# Obtain token for seeded admin
+TOKEN=$(curl -s -X POST http://localhost:5055/api/login \
+  -H 'Content-Type: application/json' \
+  -d '{"email": "admin@pharma.com", "password": "adminpass"}' | \
+  python -c 'import sys, json; print(json.load(sys.stdin)["token"])')
+
+echo "Obtained admin token: $TOKEN"
+
+# Register a new manufacturer organization
+curl -s -X POST http://localhost:5055/api/organizations \
+  -H "Authorization: Bearer $TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{"organization_id": "MANUF_EXTRA", "name": "Extra Manufacturer", "type": "Manufacturer"}'
+
+echo "Added manufacturer MANUF_EXTRA"
+
+# Add sample product under new manufacturer
+curl -s -X POST http://localhost:5055/api/products \
+  -H "Authorization: Bearer $TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{"name": "Test Product", "sku": "TEST123", "manufacturer_org_id": "MANUF_EXTRA"}'
+
+echo "Added sample product TEST123"
+
+# Shutdown server
+kill $APP_PID
+wait $APP_PID 2>/dev/null || true
+
+echo "Setup complete."


### PR DESCRIPTION
## Summary
- add `ubuntu_setup.sh` helper
- document new script in README
- bump backend version to 0.2.3

## Testing
- `python -m backend.run`
- `bash ubuntu_setup.sh`

------
https://chatgpt.com/codex/tasks/task_e_685ac12b0eec832a924658c96947c139